### PR TITLE
Fix Jetbrains link when using Firefox

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "Open GitHub in IDE",
   "author": "Louis-Marie Michelin",
   "homepage_url": "https://github.com/lmichelin/open-github-links-in-ide",
-  "permissions": ["storage"],
+  "permissions": ["storage", "*://localhost/*"],
   "content_scripts": [
     {
       "run_at": "document_end",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "Open GitHub in IDE",
   "author": "Louis-Marie Michelin",
   "homepage_url": "https://github.com/lmichelin/open-github-links-in-ide",
-  "permissions": ["storage", "*://localhost/*"],
+  "permissions": ["storage"],
   "content_scripts": [
     {
       "run_at": "document_end",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,9 @@ const generatePlugins = (env, mode, browser) => {
               manifest.browser_specific_settings = {
                 gecko: { id: process.env.npm_package_geckoId },
               }
+              // Allow extension to fetch localhost URLs on Firefox (permission not needed on Chrome)
+              // https://github.com/github/fetch/issues/310#issuecomment-454662463
+              manifest.permissions.push("*://localhost/*")
             }
             return Buffer.from(JSON.stringify(manifest))
           },


### PR DESCRIPTION
The builtin JB web server doesn't work for Firefox, I think this is the reason:
https://github.com/github/fetch/issues/310#issuecomment-454662463