### PR TITLE
update default repo path to be more informative

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export type ChromeStorage = {
 }
 
 export const defaultChromeStorageOptions: ChromeStorage = {
-  localPathForRepositories: "/home/changeMe",
+  localPathForRepositories: "/Users/[username]/path/to/repos/folder",
   defaultIde: "vscode",
   showIconInFileTree: true,
   showIconOnFileBlockHeaders: true,


### PR DESCRIPTION
Hi thanks so much for the great extension, it's exactly what I needed!

I had some trouble at first getting the path to work, bc I was trying things like `~/path/to/repos/folder/` instead of `Users/...`

I don't know what the windows equivalent would be for this, but maybe an idea of how to make it more informative. 

Thanks!