### PR TITLE
feat: add button in comments

### DIFF
--- a/src/inject.ts
+++ b/src/inject.ts
@@ -82,6 +82,42 @@ const run = async () => {
     // -------------------------------
     // repository content (files list)
     // -------------------------------
+    {
+      const files = document.querySelectorAll(
+        ".js-comment > .TimelineItem > .TimelineItem-body > details > summary .Link--primary",
+      )
+
+      files.forEach(fileElement => {
+        // don't add a new icon if icon already exists
+        if (fileElement.parentNode?.querySelector(".open-in-ide-icon")) return
+
+        const href = fileElement.getAttribute("href")
+        if (!href) return
+
+        const repo = /\/([^/]+)\/([^/]+)/.exec(href)?.[2]
+        const file = fileElement.textContent
+        if (!repo || !file) return
+
+        // in discussion
+        const lineNumberNodes =
+          fileElement.parentNode?.parentNode?.parentNode?.parentNode?.querySelectorAll("td[data-line-number]")
+
+        if (!lineNumberNodes?.length) return // length can be equal to zero in case of resolved comment for example
+
+        // get last line number
+        const lineNumberForFileBlock = lineNumberNodes[lineNumberNodes.length - 1].getAttribute("data-line-number")
+
+        const editorIconElement = generateIconElement(repo, file, lineNumberForFileBlock)
+        editorIconElement.classList.add("ml-2")
+
+        fileElement.parentNode?.append(editorIconElement)
+        addedIconsCounter++
+      })
+    }
+
+    // -------------------------------
+    // repository content (files list)
+    // -------------------------------
 
     if (OPTIONS.showIconInFileTree) {
       const files = document.querySelectorAll(


### PR DESCRIPTION
Add an button to open IDE in comments like:

![企业微信截图_c917f78b-8a43-4a4e-9f55-7a81fa57c884](https://user-images.githubusercontent.com/18693190/168268462-4f60ff09-2aa1-4fd5-ab32-08539eb954cd.png)

# TODOs

- [ ] optimize `fileElement` https://github.com/lmichelin/open-github-links-in-ide/pull/33#discussion_r872257182
- [ ] add configuration
- [ ] maybe test need to be added?